### PR TITLE
Make `Q` test future-proof

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -1,7 +1,7 @@
 name = "SemiseparableMatrices"
 uuid = "f8ebbe35-cbfb-4060-bf7f-b10e4670cf57"
 authors = ["Sheehan Olver <solver@mac.com>"]
-version = "0.3.4"
+version = "0.3.5"
 
 [deps]
 ArrayLayouts = "4c555306-a7a7-4459-81d9-ec55ddd5c99a"

--- a/test/test_almostbanded.jl
+++ b/test/test_almostbanded.jl
@@ -153,7 +153,7 @@ Random.seed!(0)
         @test A \ b ≈ Matrix(A) \ b 
         @test all(A \ b .=== F \ b .=== F.R \ (F.Q'*b)) 
         Q̃ = QRPackedQ(F.factors,F.τ)
-        @test Q̃ ≈ F.Q
+        @test Matrix(Q̃) ≈ Matrix(F.Q)
         @test lmul!(Q̃,copy(b)) ≈ lmul!(F.Q,copy(b)) ≈ Matrix(F.Q)*b
         @test lmul!(Q̃',copy(b)) ≈ lmul!(F.Q',copy(b)) ≈ Matrix(F.Q)'*b
 


### PR DESCRIPTION
This needs a new version so that I can test this on the `AbstractQ` PR in Julia Base via nanosoldier.